### PR TITLE
fix: exposed ports on spm

### DIFF
--- a/docker-compose-spm.yaml
+++ b/docker-compose-spm.yaml
@@ -65,10 +65,6 @@ services:
       - "--collector.otlp.enabled=true"
     environment: 
       - SAMPLING_CONFIG_TYPE=adaptive
-    ports:
-      - "4317" # accept OpenTelemetry Protocol (OTLP) over gRPC
-      - "4318" # accept OpenTelemetry Protocol (OTLP) over HTTP
-      - "14250" # accept model.proto
     restart: on-failure
     depends_on:
       - cassandra-schema
@@ -106,9 +102,9 @@ services:
     volumes:
       - ./etc/otel-collector-config-spm.yaml:/conf/config.yaml
     ports:
-      - "4317" # OTLP gRPC receiver
-      - "4318" # OTLP http receiver
-      - "8889" # Prometheus metrics exporter
+      - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318" # OTLP http receiver
+      - "8889:8889" # Prometheus metrics exporter
     restart: on-failure
     depends_on:
       - jaeger-collector


### PR DESCRIPTION
Hey @blueswen, thanks for the great job!

I noticed the ports exposed by `docker-compose-spm.yaml` where random because there was no binding rule.
Then, based on your SPM diagram, only the otel-collector service should expose the grcp/http ports to the external network, therefore I removed the jaeger-collector ones since they were not needed.

![image](https://github.com/user-attachments/assets/12718746-5b6e-4f86-983c-d7b55f84e7ab)

Now it is all working 